### PR TITLE
Fix avatar shape on homepage

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -24,3 +24,11 @@ transition: transform .2s ease, box-shadow .2s ease;
 
 // 页眉按钮更显眼
 .btn--primary { border-radius: .75rem; padding: .55rem 1rem; }
+
+// 头像裁剪为正圆
+.author__avatar img {
+  width: 110px;
+  height: 110px;
+  object-fit: cover;
+  border-radius: 50%;
+}


### PR DESCRIPTION
## Summary
- Crop author profile avatar to a circle by forcing square size and cover fit

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f1f1685483329c9f0c1dd68ad030